### PR TITLE
[FIX] bi_sql_editor speed of manual field check

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -730,9 +730,9 @@ class BiSQLView(models.Model):
     def check_manual_fields(self, model):
         # check the fields we need are defined on self, to stop it going
         # early on install / startup - particularly problematic during upgrade
-        if "group_operator" in table_columns(
-            self.env.cr, "bi_sql_view_field"
-        ) and model._name.startswith(self._model_prefix):
+        if model._name.startswith(
+            self._model_prefix
+        ) and "group_operator" in table_columns(self.env.cr, "bi_sql_view_field"):
             # Use SQL instead of ORM, as ORM might not be fully initialised -
             # we have no control over the order that fields are defined!
             # We are not concerned about user security rules.


### PR DESCRIPTION
`check_manual_fields()` is hit quite a lot when loading addons. Improved by replacing a `startswith` with a faster slicing.