### PR TITLE
[IMP] report_py3o: ignore libreoffice dependency

### DIFF
--- a/report_py3o/__manifest__.py
+++ b/report_py3o/__manifest__.py
@@ -12,7 +12,7 @@
     "depends": ["web"],
     "external_dependencies": {
         "python": ["py3o.template", "py3o.formats"],
-        "bin": ["libreoffice"],
+        "deb": ["libreoffice"],
     },
     "assets": {
         "web.assets_backend": [


### PR DESCRIPTION
According to the [Odoo documentation](https://www.odoo.com/documentation/17.0/developer/reference/backend/module.html?highlight=external_dependencies), external dependencies should be specified using the bin key. Currently, we want to ignore the LibreOffice dependency because of its size and impact.